### PR TITLE
feat: [sc-140703] Deploy systems without load balancer on ICP

### DIFF
--- a/modules/container-definition/main.tf
+++ b/modules/container-definition/main.tf
@@ -19,11 +19,13 @@ locals {
 
   linux_parameters = var.enable_execute_command ? merge({ "initProcessEnabled" : true }, var.linux_parameters) : merge({ "initProcessEnabled" : false }, var.linux_parameters)
 
-  health_check = length(var.health_check) > 0 ? merge({
-    interval = 30,
-    retries  = 3,
-    timeout  = 5
-  }, var.health_check) : null
+  health_check = upper(var.load_balancer_type) == "NONE" ? null : (
+    length(coalesce(var.health_check, {})) > 0 ? merge({
+      interval = var.health_check_interval,
+      retries  = var.health_check_retries,
+      timeout  = var.health_check_timeout
+    }, coalesce(var.health_check, {})) : null
+  )
 
   definition = {
     command                = length(var.command) > 0 ? var.command : null

--- a/modules/container-definition/variables.tf
+++ b/modules/container-definition/variables.tf
@@ -321,3 +321,28 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "health_check" {
+  type    = map(any)
+  default = {}
+}
+
+variable "health_check_interval" {
+  type    = number
+  default = 30
+}
+
+variable "health_check_retries" {
+  type    = number
+  default = 3
+}
+
+variable "health_check_timeout" {
+  type    = number
+  default = 5
+}
+
+variable "load_balancer_type" {
+  type    = string
+  default = "BOTH"
+}


### PR DESCRIPTION
## Why?

Not all the systems need a load balancer and on ICP nowadays we don't support systems without one as we have specified [here](https://engdocs.internal.vio.com/icp/systems/service/#public-and-private-load-balancer-endpoints). BoVio team brought up to us a case where they don't need it and a workaround had to be applied to skip this necessity.

## What?

Give the option to our customers to choose between a PRIVATE, PUBLIC, BOTH or NONE load balancer once managing their systems in the [system-ingress](https://github.com/FindHotel/cloud-platform-modules/blob/main/modules/service-system/modules/system-ingress).